### PR TITLE
EOL: replaced by rocks.noise.qspeakers

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+  "end-of-life": "The application has been renamed to rocks.noise.qspeakers.",
+  "end-of-life-rebase": "rocks.noise.qspeakers"
+}


### PR DESCRIPTION
The title says it all.